### PR TITLE
Update dependency references in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,15 @@ If you want to use the Liquibase HANA extension in an application project, add t
 
 ```xml
 <dependency>
-    <groupId>com.sap.foss.hana</groupId>
-    <artifactId>liquibase-hana</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+     <groupId>org.liquibase.ext</groupId>
+     <artifactId>liquibase-hanadb</artifactId>
+     <version>3.9.0</version>
 </dependency>
 ```
 
 ### Gradle
 ```
-implementation 'com.sap.foss.hana:liquibase-hana:1.0.2-SNAPSHOT'
+implementation 'org.liquibase.ext:liquibase-hanadb:3.9.0'
 ```
 
 # How to obtain support


### PR DESCRIPTION
The Maven groupId, artifactId adn version was outdated  in the README. 
Updated from com.sap.foss.hana, liquibase-hana, 1.0.2-SNAPSHOT  -->  org.liquibase.ext, liquibase-hanadb, 3.9.0