### PR TITLE
Add support for NO ACTION enum value of onDelete and onUpdate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
 - chmod -R 777 $TRAVIS_BUILD_DIR/HXE
 - echo $PASSWORD_FILE_CONTENT > $TRAVIS_BUILD_DIR/HXE/$PASSWORD_FILE_NAME
 - chmod 777 $TRAVIS_BUILD_DIR/HXE/$PASSWORD_FILE_NAME
-- echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+- echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
 - docker pull store/saplabs/hanaexpress:$HXE_VERSION
 - docker run -d -p 39013:39013 -p 39015:39015 -p 39017:39017 -p 39041-39045:39041-39045
   -p 1128-1129:1128-1129 -p 59013-59014:59013-59014 -v $TRAVIS_BUILD_DIR/HXE:/hana/mounts

--- a/src/main/java/liquibase/ext/hana/sqlgenerator/AddForeignKeyConstraintGeneratorHana.java
+++ b/src/main/java/liquibase/ext/hana/sqlgenerator/AddForeignKeyConstraintGeneratorHana.java
@@ -48,14 +48,8 @@ public class AddForeignKeyConstraintGeneratorHana extends AddForeignKeyConstrain
             sb.append(" ON DELETE ").append(statement.getOnDelete());
         }
 
-        if (statement.isDeferrable() || statement.isInitiallyDeferred()) {
-            if (statement.isDeferrable()) {
-                sb.append(" DEFERRABLE");
-            }
-
-            if (statement.isInitiallyDeferred()) {
-                sb.append(" INITIALLY DEFERRED");
-            }
+        if (statement.isInitiallyDeferred()) {
+            sb.append(" INITIALLY DEFERRED");
         }
 
         return new Sql[] { new UnparsedSql(sb.toString(), getAffectedForeignKey(statement)) };

--- a/src/main/java/liquibase/ext/hana/sqlgenerator/AddForeignKeyConstraintGeneratorHana.java
+++ b/src/main/java/liquibase/ext/hana/sqlgenerator/AddForeignKeyConstraintGeneratorHana.java
@@ -1,0 +1,63 @@
+package liquibase.ext.hana.sqlgenerator;
+
+import liquibase.database.Database;
+import liquibase.ext.hana.HanaDatabase;
+import liquibase.sql.Sql;
+import liquibase.sql.UnparsedSql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.AddForeignKeyConstraintGenerator;
+import liquibase.statement.core.AddForeignKeyConstraintStatement;
+
+/**
+ * SQL generator for "add foreign key constraint" statements. This generator allows to have NO ACTION in the
+ * onUpdate and onDelete properties
+ *
+ * @author gbandsmith
+ */
+public class AddForeignKeyConstraintGeneratorHana extends AddForeignKeyConstraintGenerator {
+
+    @Override
+    public int getPriority() {
+        return PRIORITY_DATABASE;
+    }
+
+    @Override
+    public boolean supports(AddForeignKeyConstraintStatement statement, Database database) {
+        return database instanceof HanaDatabase;
+    }
+
+    @Override
+    public Sql[] generateSql(AddForeignKeyConstraintStatement statement, Database database,
+            SqlGeneratorChain sqlGeneratorChain) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("ALTER TABLE ")
+                .append(database.escapeTableName(statement.getBaseTableCatalogName(),
+                        statement.getBaseTableSchemaName(), statement.getBaseTableName()))
+                .append(" ADD CONSTRAINT ").append(database.escapeConstraintName(statement.getConstraintName()))
+                .append(" FOREIGN KEY (").append(database.escapeColumnNameList(statement.getBaseColumnNames()))
+                .append(") REFERENCES ")
+                .append(database.escapeTableName(statement.getReferencedTableCatalogName(),
+                        statement.getReferencedTableSchemaName(), statement.getReferencedTableName()))
+                .append(" (").append(database.escapeColumnNameList(statement.getReferencedColumnNames())).append(")");
+        // HANA does not have ON UPDATE NO ACTION statement
+        if (statement.getOnUpdate() != null && !"NO ACTION".equalsIgnoreCase(statement.getOnUpdate())) {
+            sb.append(" ON UPDATE ").append(statement.getOnUpdate());
+        }
+        // HANA does not have ON DELETE NO ACTION statement
+        if (statement.getOnDelete() != null && !"NO ACTION".equalsIgnoreCase(statement.getOnDelete())) {
+            sb.append(" ON DELETE ").append(statement.getOnDelete());
+        }
+
+        if (statement.isDeferrable() || statement.isInitiallyDeferred()) {
+            if (statement.isDeferrable()) {
+                sb.append(" DEFERRABLE");
+            }
+
+            if (statement.isInitiallyDeferred()) {
+                sb.append(" INITIALLY DEFERRED");
+            }
+        }
+
+        return new Sql[] { new UnparsedSql(sb.toString(), getAffectedForeignKey(statement)) };
+    }
+}

--- a/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
+++ b/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
@@ -1,6 +1,7 @@
 liquibase.ext.hana.sqlgenerator.AddAutoIncrementGeneratorHana
 liquibase.ext.hana.sqlgenerator.AddColumnGeneratorHana
 liquibase.ext.hana.sqlgenerator.AddDefaultValueGeneratorHana
+liquibase.ext.hana.sqlgenerator.AddForeignKeyConstraintGeneratorHana
 liquibase.ext.hana.sqlgenerator.AlterSequenceGeneratorHana
 liquibase.ext.hana.sqlgenerator.AlterTableStoreGenerator
 liquibase.ext.hana.sqlgenerator.CreateDatabaseChangeLogLockTableGeneratorHana

--- a/src/test/java/liquibase/ext/hana/change/AddForeignKeyChangeTest.java
+++ b/src/test/java/liquibase/ext/hana/change/AddForeignKeyChangeTest.java
@@ -1,0 +1,22 @@
+package liquibase.ext.hana.change;
+
+import org.junit.*;
+
+import liquibase.ext.hana.testing.BaseTestCase;
+
+public class AddForeignKeyChangeTest extends BaseTestCase {
+    @Before
+    public void setUp() throws Exception {
+        changeLogFile = "changelogs/AddForeignKeyChangelog/changelog.test.xml";
+        connectToDB();
+        cleanDB();
+    }
+
+    @Test
+    public void test() throws Exception {
+        if (connection == null) {
+            return;
+        }
+        liquiBase.update((String) null);
+    }
+}

--- a/src/test/java/liquibase/ext/hana/sqlgenerator/AddForeignKeyConstraintGeneratorHanaTest.java
+++ b/src/test/java/liquibase/ext/hana/sqlgenerator/AddForeignKeyConstraintGeneratorHanaTest.java
@@ -1,0 +1,49 @@
+package liquibase.ext.hana.sqlgenerator;
+
+import liquibase.change.ColumnConfig;
+import liquibase.ext.hana.HanaDatabase;
+import liquibase.sql.Sql;
+import liquibase.statement.core.AddForeignKeyConstraintStatement;
+import liquibase.structure.core.Column;
+import org.junit.*;
+
+import static org.junit.Assert.*;
+
+public class AddForeignKeyConstraintGeneratorHanaTest {
+    private HanaDatabase database = new HanaDatabase();
+    private AddForeignKeyConstraintGeneratorHana generator = new AddForeignKeyConstraintGeneratorHana();
+    private ColumnConfig baseColumn = new ColumnConfig(new Column("baseid"));
+    private ColumnConfig refColumn = new ColumnConfig(new Column("referencekey"));
+
+    @Test
+    public void testAddForeignKeyNoCascade() {
+        AddForeignKeyConstraintStatement statement = new AddForeignKeyConstraintStatement("fk", null,
+                null, "basetable", new ColumnConfig[]{baseColumn}, null, null,
+                "referencetable", new ColumnConfig[]{refColumn});
+        final Sql[] sql = generator.generateSql(statement, database, null);
+        assertEquals(1, sql.length);
+        assertEquals("ALTER TABLE basetable ADD CONSTRAINT fk FOREIGN KEY (baseid) REFERENCES referencetable (referencekey)", sql[0].toSql());
+    }
+    @Test
+    public void testAddForeignKeyCascadeNoAction() {
+        AddForeignKeyConstraintStatement statement = new AddForeignKeyConstraintStatement("fk", null,
+                null, "basetable", new ColumnConfig[]{baseColumn}, null, null,
+                "referencetable", new ColumnConfig[]{refColumn});
+        statement.setOnDelete("no action");
+        statement.setOnUpdate("no action");
+        final Sql[] sql = generator.generateSql(statement, database, null);
+        assertEquals(1, sql.length);
+        assertEquals("ALTER TABLE basetable ADD CONSTRAINT fk FOREIGN KEY (baseid) REFERENCES referencetable (referencekey)", sql[0].toSql());
+    }
+    @Test
+    public void testAddForeignKeyCascadeDeleteAndUpdate() {
+        AddForeignKeyConstraintStatement statement = new AddForeignKeyConstraintStatement("fk", null,
+                null, "basetable", new ColumnConfig[]{baseColumn}, null, null,
+                "referencetable", new ColumnConfig[]{refColumn});
+        statement.setOnDelete("cascade");
+        statement.setOnUpdate("set null");
+        final Sql[] sql = generator.generateSql(statement, database, null);
+        assertEquals(1, sql.length);
+        assertEquals("ALTER TABLE basetable ADD CONSTRAINT fk FOREIGN KEY (baseid) REFERENCES referencetable (referencekey) ON UPDATE set null ON DELETE cascade", sql[0].toSql());
+    }
+}

--- a/src/test/resources/changelogs/AddForeignKeyChangelog/changelog.test.xml
+++ b/src/test/resources/changelogs/AddForeignKeyChangelog/changelog.test.xml
@@ -1,0 +1,22 @@
+<databaseChangeLog
+	xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+	xmlns:hana="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd
+        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+	<changeSet author="breglerj" id="1">
+		<sql>CREATE ROW TABLE MY_TAB(id int, text nvarchar(255))</sql>
+		<sql>CREATE ROW TABLE MY_TAB2(id int, fk int, fk2 int)</sql>
+		<addPrimaryKey columnNames="id" tableName="MY_TAB"/>
+		<addPrimaryKey columnNames="id" tableName="MY_TAB2"/>
+	</changeSet>
+
+	<changeSet id="2" author="fdambrine">
+		<addForeignKeyConstraint baseTableName="MY_TAB2" baseColumnNames="fk" constraintName="fktest"
+								 referencedTableName="MY_TAB" referencedColumnNames="id" onDelete="NO ACTION"/>
+		<addForeignKeyConstraint baseTableName="MY_TAB2" baseColumnNames="fk2" constraintName="fktest2"
+								 referencedTableName="MY_TAB" referencedColumnNames="id" onDelete="CASCADE"/>
+	</changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
Hello,

Adding HANA support in our existing application whose changelog was partially auto generated by liquibase tool we face an issue when we have to run change sets as 

```xml
<addForeignKeyConstraint baseTableName="MY_TAB2" baseColumnNames="fk" constraintName="fktest"
								 referencedTableName="MY_TAB" referencedColumnNames="id" onDelete="NO ACTION" onUpdate="NO ACTION"/>
```

This PR creates an override of `AddForeignKeyConstraintGenerator` that will ignore NO ACTION value when we are on HANA database.



┆Issue is synchronized with this [Jira Bug](https://datical.atlassian.net/browse/LB-560) by [Unito](https://www.unito.io/learn-more)
