### PR TITLE
tgz: Set failOnDefferable to false to avoid failing on existing/generated changesets

### DIFF
--- a/src/main/java/liquibase/ext/hana/HanaDatabase.java
+++ b/src/main/java/liquibase/ext/hana/HanaDatabase.java
@@ -142,6 +142,11 @@ public class HanaDatabase extends AbstractJdbcDatabase {
     }
 
     @Override
+    public boolean failOnDefferable() {
+        return false;
+    }
+
+    @Override
     public boolean supportsSequences() {
         return true;
     }


### PR DESCRIPTION
PROPOSAL: Dont fail when an existing, like a generated, changeset has defferable attributes on FKs.