### PR TITLE
fix incorrect priority for non hana sequences

### DIFF
--- a/src/main/java/liquibase/ext/hana/snapshot/SequenceSnapshotGeneratorHana.java
+++ b/src/main/java/liquibase/ext/hana/snapshot/SequenceSnapshotGeneratorHana.java
@@ -13,11 +13,12 @@ public class SequenceSnapshotGeneratorHana extends SequenceSnapshotGenerator {
 
     @Override
     public int getPriority(Class<? extends DatabaseObject> objectType, Database database) {
-        int priority = super.getPriority(objectType, database);
         if (database instanceof HanaDatabase) {
-            priority += PRIORITY_DATABASE;
+            int priority = super.getPriority(objectType, database);
+            return priority + PRIORITY_DATABASE;
+        } else {
+            return PRIORITY_NONE;
         }
-        return priority;
     }
 
     @Override


### PR DESCRIPTION
Closes https://github.com/liquibase/liquibase-hanadb/issues/259
We recently encountered an issue in migrations. When the Hana extension is present, Snowflake sequences are processed by SequenceSnapshotGeneratorHana, which leads to the error shown in the issue. 
The fix makes HanaSequenceGenerator to ignore any non-Hana sequences